### PR TITLE
Add Deliberate & Reliberate by XpucT

### DIFF
--- a/src/parti_prompts.py
+++ b/src/parti_prompts.py
@@ -175,6 +175,42 @@ MODEL_MAP = [
             },
         },
     },
+    {
+        "name": "Deliberate v6",
+        "type": "fal",
+        "url": "https://huggingface.co/XpucT/Deliberate",
+        "fal": {
+            "model_id": "XpucT/Deliberate",
+            "playground": "https://fal.ai/models/fal-ai/lora",
+            "params": {
+                "image_size": {
+                    "width": 512,
+                    "height": 512,
+                },
+                "num_inference_steps": 30,
+                "guidance_scale": 6,
+            },
+        },
+        
+    },
+    {
+        "name": "Reliberate v3",
+        "type": "fal",
+        "url": "https://huggingface.co/XpucT/Reliberate",
+        "fal": {
+            "model_id": "XpucT/Reliberate",
+            "playground": "https://fal.ai/models/fal-ai/lora",
+            "params": {
+                "image_size": {
+                    "width": 512,
+                    "height": 512,
+                },
+                "num_inference_steps": 30,
+                "guidance_scale": 6,
+            },
+        },
+        
+    },
 ]
 
 


### PR DESCRIPTION
Good afternoon, I propose to add the best SD1.5 models in the world made by XpucT - Deliberate and Reliberate.

Peculiarities:
- These two models were trained on huge datasets of the highest quality images
- XpucT created new cool scripts for training
- These two models are universal for all tasks

I hope that these models will enter the arena of models and take their rightful place in the top.

Optimal settings:
- Sampler: Euler a
- Inference Steps: 25-35 (optimal 30)
- Guidance Scale: 5.5-7.5 (optimal 6)
- Resolution: Supports all resolution SD1.5 models

Links:
- Official Deliberate repo (not diffusers, only single file): [here](https://huggingface.co/XpucT/Deliberate)
- Official Reliberate repo (not diffusers, only single file): [here](https://huggingface.co/XpucT/Reliberate)
- Unofficial Deliberate repo (diffusers format): [here](https://huggingface.co/ehristoforu/deliberate-v6-diffusers-unofficial)
- Unofficial Reliberate repo (diffusers format): [here](https://huggingface.co/ehristoforu/reliberate-v3-diffusers-unofficial)


![preview_XpucT](https://github.com/fal-ai/imgsys-public/assets/136880927/5993b413-909d-4b3b-8309-24bc6e205aed)
